### PR TITLE
fix: increase output storage for GWAS workflows

### DIFF
--- a/cwl/gwas_workflow/CWL/create_plot.cwl
+++ b/cwl/gwas_workflow/CWL/create_plot.cwl
@@ -12,7 +12,7 @@ hints:
   - class: ResourceRequirement
     coresMin: 2
     ramMin: 1024
-    outdirMin: 1024
+    outdirMin: 25600
 
 inputs:
   - id: logistic

--- a/cwl/gwas_workflow/CWL/parse_metadata.cwl
+++ b/cwl/gwas_workflow/CWL/parse_metadata.cwl
@@ -12,7 +12,7 @@ hints:
   - class: ResourceRequirement
     coresMin: 1
     ramMin: 1024
-    outdirMin: 1024
+    outdirMin: 25600
 
 inputs:
   - id: metadata

--- a/cwl/gwas_workflow/CWL_trs/create_plot.cwl
+++ b/cwl/gwas_workflow/CWL_trs/create_plot.cwl
@@ -12,7 +12,7 @@ hints:
   - class: ResourceRequirement
     coresMin: 2
     ramMin: 1024
-    outdirMin: 1024
+    outdirMin: 25600
 
 inputs:
   - id: logistic

--- a/cwl/gwas_workflow/CWL_trs/parse_metadata.cwl
+++ b/cwl/gwas_workflow/CWL_trs/parse_metadata.cwl
@@ -12,7 +12,7 @@ hints:
   - class: ResourceRequirement
     coresMin: 1
     ramMin: 1024
-    outdirMin: 1024
+    outdirMin: 25600
 
 inputs:
   - id: metadata

--- a/cwl/gwas_workflow/CWL_trs/run_gwas.cwl
+++ b/cwl/gwas_workflow/CWL_trs/run_gwas.cwl
@@ -12,7 +12,7 @@ hints:
   - class: ResourceRequirement
     coresMin: 1
     ramMin: 1024
-    outdirMin: 1024
+    outdirMin: 25600
 
 inputs:
   - id: variants


### PR DESCRIPTION
* increase `outdirMin` from `1024` to `25600` in all steps of the GWAS analysis demo workflows